### PR TITLE
Change search info bottom sheet background color to white

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -518,7 +518,7 @@ const Navigator: React.FC<Props> = ({
           customStyles={{
             container: {
               ...styles.sheetContainer,
-              backgroundColor: lightTheme.colors.headerBackground,
+              backgroundColor: WHITE,
             },
             draggableIcon: styles.draggableIcon,
           }}>


### PR DESCRIPTION
Resolves #16.

Changes the background color of `SearchInfoBottomSheet` to white.