### PR TITLE
Removed unnecessary http-exceptions

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">smartmet-demo.fmi.fi</domain>
+        <!-- <domain includeSubdomains="true">smartmet-demo.fmi.fi</domain> -->
         <domain includeSubdomains="true">alert.metservice.gov.jm</domain>
     </domain-config>
 </network-security-config>

--- a/ios/MobileWeather/Info.plist
+++ b/ios/MobileWeather/Info.plist
@@ -46,16 +46,6 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>smartmet-demo.fmi.fi</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 		</dict>
 	</dict>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>


### PR DESCRIPTION
resolves #6 

Android:
- deleted localhost and 10.0.2.2
- commented off demo-smartmet

IOS
- deleted demo-smartmet

So both have only jm-smartmetserver url as exception.